### PR TITLE
Use calc when calculating the offset

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -615,7 +615,7 @@ _reactDom.default.render(_react.default.createElement(App, null), container);
 
 module.exports = require('./src');
 
-},{"./src":27}],3:[function(require,module,exports){
+},{"./src":28}],3:[function(require,module,exports){
 'use strict'
 
 module.exports = require('./src')
@@ -24552,7 +24552,7 @@ function (_PureComponent) {
 
 exports.default = Popover;
 
-},{"./PopoverContent":26,"./throttle":28,"@rpearce/simple-uniqueid":3,"react":18,"react-button-a11y":9,"react-dom":13}],26:[function(require,module,exports){
+},{"./PopoverContent":26,"./throttle":29,"@rpearce/simple-uniqueid":3,"react":18,"react-button-a11y":9,"react-dom":13}],26:[function(require,module,exports){
 "use strict";
 
 function _typeof2(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof2 = function _typeof2(obj) { return typeof obj; }; } else { _typeof2 = function _typeof2(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof2(obj); }
@@ -24565,6 +24565,8 @@ exports.default = exports.PopoverContent = void 0;
 var _react = _interopRequireWildcard(require("react"));
 
 var _reactWithForwardedRef = _interopRequireDefault(require("react-with-forwarded-ref"));
+
+var _getPCStyle = _interopRequireDefault(require("./getPCStyle"));
 
 function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {
@@ -24734,62 +24736,6 @@ function _setPrototypeOf(o, p) {
   return _setPrototypeOf(o, p);
 }
 
-var getStyle = function getStyle(_ref) {
-  var dirBottom = _ref.dirBottom,
-      dirLeft = _ref.dirLeft,
-      dirRight = _ref.dirRight,
-      dirTop = _ref.dirTop,
-      height = _ref.height,
-      isOpen = _ref.isOpen,
-      _offset = _ref.offset,
-      style = _ref.style,
-      triggerRect = _ref.triggerRect,
-      width = _ref.width;
-  var zIndex = '999';
-  var initial = Object.assign({}, {
-    zIndex: zIndex
-  }, style, {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    opacity: isOpen ? 1 : 0,
-    visibility: isOpen ? 'visible' : 'hidden'
-  });
-
-  if (!isOpen || !triggerRect) {
-    return initial;
-  }
-
-  var offset = _offset || 0;
-  var realTop = window.pageYOffset + triggerRect.top;
-  var realLeft = window.pageXOffset + triggerRect.left;
-  var toTop = {
-    top: realTop - height - offset
-  };
-  var toRight = {
-    left: realLeft + triggerRect.width + offset
-  };
-  var toBottom = {
-    top: realTop + triggerRect.height + offset
-  };
-  var toLeft = {
-    left: realLeft - width - offset
-  };
-  var toMiddleX = {
-    left: realLeft + triggerRect.width / 2 - width / 2
-  };
-  var toMiddleY = {
-    top: realTop + triggerRect.height / 2 - height / 2
-  };
-  var isOutsideTop = triggerRect.top - height <= 0;
-  var isOutsideRight = triggerRect.left + width >= window.innerWidth;
-  var isOutsideBottom = triggerRect.top + triggerRect.height + height >= window.innerHeight;
-  var isOutsideLeft = triggerRect.left - width <= 0;
-  return Object.assign({}, initial, toBottom, // default
-  toMiddleX, // default
-  dirTop && toTop, dirRight && toRight, dirBottom && toBottom, dirLeft && toLeft, (dirTop || dirBottom) && !dirLeft && !dirRight && toMiddleX, (dirRight || dirLeft) && !dirTop && !dirBottom && toMiddleY, isOutsideTop && toBottom, isOutsideRight && toLeft, isOutsideBottom && toTop, isOutsideLeft && toRight);
-};
-
 var PopoverContent =
 /*#__PURE__*/
 function (_Component) {
@@ -24871,7 +24817,7 @@ function (_Component) {
           height = _this$state2.height,
           width = _this$state2.width;
 
-      var newStyle = getStyle({
+      var newStyle = (0, _getPCStyle.default)({
         dirBottom: dirBottom,
         dirLeft: dirLeft,
         dirRight: dirRight,
@@ -24904,7 +24850,82 @@ var _default = (0, _reactWithForwardedRef.default)(PopoverContent);
 
 exports.default = _default;
 
-},{"react":18,"react-with-forwarded-ref":14}],27:[function(require,module,exports){
+},{"./getPCStyle":27,"react":18,"react-with-forwarded-ref":14}],27:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var parseOffset = function parseOffset(offset) {
+  if (!offset || parseFloat(offset) === 0) {
+    return '0px';
+  }
+
+  return typeof offset === 'number' ? "".concat(offset, "px") : offset;
+};
+
+var getPCStyle = function getPCStyle(_ref) {
+  var dirBottom = _ref.dirBottom,
+      dirLeft = _ref.dirLeft,
+      dirRight = _ref.dirRight,
+      dirTop = _ref.dirTop,
+      height = _ref.height,
+      isOpen = _ref.isOpen,
+      _offset = _ref.offset,
+      style = _ref.style,
+      triggerRect = _ref.triggerRect,
+      width = _ref.width;
+  var zIndex = '999';
+  var initial = Object.assign({}, {
+    zIndex: zIndex
+  }, style, {
+    position: 'absolute',
+    top: '0',
+    left: '0',
+    opacity: isOpen ? '1' : '0',
+    visibility: isOpen ? 'visible' : 'hidden'
+  });
+
+  if (!isOpen || !triggerRect) {
+    return initial;
+  }
+
+  var offset = parseOffset(_offset);
+  var realTop = window.pageYOffset + triggerRect.top;
+  var realLeft = window.pageXOffset + triggerRect.left;
+  var toTop = {
+    top: "calc(".concat(realTop - height, "px - ").concat(offset, ")")
+  };
+  var toRight = {
+    left: "calc(".concat(realLeft + triggerRect.width, "px + ").concat(offset, ")")
+  };
+  var toBottom = {
+    top: "calc(".concat(realTop + triggerRect.height, "px + ").concat(offset, ")")
+  };
+  var toLeft = {
+    left: "calc(".concat(realLeft - width, "px - ").concat(offset, ")")
+  };
+  var toMiddleX = {
+    left: "".concat(realLeft + triggerRect.width / 2 - width / 2, "px")
+  };
+  var toMiddleY = {
+    top: "".concat(realTop + triggerRect.height / 2 - height / 2, "px")
+  };
+  var isOutsideTop = triggerRect.top - height <= 0;
+  var isOutsideRight = triggerRect.left + width >= window.innerWidth;
+  var isOutsideBottom = triggerRect.top + triggerRect.height + height >= window.innerHeight;
+  var isOutsideLeft = triggerRect.left - width <= 0;
+  return Object.assign({}, initial, toBottom, // default
+  toMiddleX, // default
+  dirTop && toTop, dirRight && toRight, dirBottom && toBottom, dirLeft && toLeft, (dirTop || dirBottom) && !dirLeft && !dirRight && toMiddleX, (dirRight || dirLeft) && !dirTop && !dirBottom && toMiddleY, isOutsideTop && toBottom, isOutsideRight && toLeft, isOutsideBottom && toTop, isOutsideLeft && toRight);
+};
+
+var _default = getPCStyle;
+exports.default = _default;
+
+},{}],28:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -24933,7 +24954,7 @@ function _interopRequireDefault(obj) {
   };
 }
 
-},{"./Popover":25,"./PopoverContent":26}],28:[function(require,module,exports){
+},{"./Popover":25,"./PopoverContent":26}],29:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {

--- a/source/PopoverContent.js
+++ b/source/PopoverContent.js
@@ -1,68 +1,7 @@
 import React, { Component } from 'react'
 import withForwardedRef from 'react-with-forwarded-ref'
 
-const getStyle = ({
-  dirBottom,
-  dirLeft,
-  dirRight,
-  dirTop,
-  height,
-  isOpen,
-  offset: _offset,
-  style,
-  triggerRect,
-  width
-}) => {
-  const zIndex = '999'
-  const initial = Object.assign({},
-    { zIndex },
-    style,
-    {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      opacity: isOpen ? 1 : 0,
-      visibility: isOpen ? 'visible' : 'hidden'
-    }
-  )
-
-  if (!isOpen || !triggerRect) {
-    return initial
-  }
-
-  const offset = _offset || 0
-
-  const realTop  = window.pageYOffset + triggerRect.top
-  const realLeft = window.pageXOffset + triggerRect.left
-
-  const toTop    = { top: realTop - height - offset }
-  const toRight  = { left: realLeft + triggerRect.width + offset }
-  const toBottom = { top: realTop + triggerRect.height + offset }
-  const toLeft   = { left: realLeft - width - offset }
-
-  const toMiddleX = { left: realLeft + (triggerRect.width / 2) - (width / 2) }
-  const toMiddleY = { top: realTop + (triggerRect.height / 2) - (height / 2) }
-
-  const isOutsideTop    = triggerRect.top - height <= 0
-  const isOutsideRight  = triggerRect.left + width >= window.innerWidth
-  const isOutsideBottom = triggerRect.top + triggerRect.height + height >= window.innerHeight
-  const isOutsideLeft   = triggerRect.left - width <= 0
-
-  return Object.assign({}, initial,
-    toBottom,  // default
-    toMiddleX, // default
-    dirTop && toTop,
-    dirRight && toRight,
-    dirBottom && toBottom,
-    dirLeft && toLeft,
-    ((dirTop || dirBottom) && !dirLeft && !dirRight) && toMiddleX,
-    ((dirRight || dirLeft) && !dirTop && !dirBottom) && toMiddleY,
-    isOutsideTop && toBottom,
-    isOutsideRight && toLeft,
-    isOutsideBottom && toTop,
-    isOutsideLeft && toRight
-  )
-}
+import getPCStyle from './getPCStyle'
 
 export class PopoverContent extends Component {
   constructor(...params) {
@@ -122,7 +61,7 @@ export class PopoverContent extends Component {
       state: { height, width }
     } = this
 
-    const newStyle = getStyle({
+    const newStyle = getPCStyle({
       dirBottom,
       dirLeft,
       dirRight,

--- a/source/getPCStyle.js
+++ b/source/getPCStyle.js
@@ -1,0 +1,74 @@
+const parseOffset = offset => {
+  if (!offset || parseFloat(offset) === 0) {
+    return '0px'
+  }
+
+  return typeof offset === 'number'
+    ? `${offset}px`
+    : offset
+}
+
+const getPCStyle = ({
+  dirBottom,
+  dirLeft,
+  dirRight,
+  dirTop,
+  height,
+  isOpen,
+  offset: _offset,
+  style,
+  triggerRect,
+  width
+}) => {
+  const zIndex = '999'
+  const initial = Object.assign({},
+    { zIndex },
+    style,
+    {
+      position: 'absolute',
+      top: '0',
+      left: '0',
+      opacity: isOpen ? '1' : '0',
+      visibility: isOpen ? 'visible' : 'hidden'
+    }
+  )
+
+  if (!isOpen || !triggerRect) {
+    return initial
+  }
+
+  const offset = parseOffset(_offset)
+
+  const realTop  = window.pageYOffset + triggerRect.top
+  const realLeft = window.pageXOffset + triggerRect.left
+
+  const toTop    = { top: `calc(${realTop - height}px - ${offset})` }
+  const toRight  = { left: `calc(${realLeft + triggerRect.width}px + ${offset})` }
+  const toBottom = { top: `calc(${realTop + triggerRect.height}px + ${offset})` }
+  const toLeft   = { left: `calc(${realLeft - width}px - ${offset})` }
+
+  const toMiddleX = { left: `${realLeft + (triggerRect.width / 2) - (width / 2)}px` }
+  const toMiddleY = { top: `${realTop + (triggerRect.height / 2) - (height / 2)}px` }
+
+  const isOutsideTop    = triggerRect.top - height <= 0
+  const isOutsideRight  = triggerRect.left + width >= window.innerWidth
+  const isOutsideBottom = triggerRect.top + triggerRect.height + height >= window.innerHeight
+  const isOutsideLeft   = triggerRect.left - width <= 0
+
+  return Object.assign({}, initial,
+    toBottom,  // default
+    toMiddleX, // default
+    dirTop && toTop,
+    dirRight && toRight,
+    dirBottom && toBottom,
+    dirLeft && toLeft,
+    ((dirTop || dirBottom) && !dirLeft && !dirRight) && toMiddleX,
+    ((dirRight || dirLeft) && !dirTop && !dirBottom) && toMiddleY,
+    isOutsideTop && toBottom,
+    isOutsideRight && toLeft,
+    isOutsideBottom && toTop,
+    isOutsideLeft && toRight
+  )
+}
+
+export default getPCStyle

--- a/test/PopoverContent.test.js
+++ b/test/PopoverContent.test.js
@@ -91,6 +91,64 @@ describe('PopoverContent', () => {
       expect(tree).toMatchSnapshot()
     })
 
+    it('renders, open & numeric offset', () => {
+      const forwardedRef = {
+        current: {
+          focus: jest.fn(),
+          offsetWidth: 150,
+          offsetHeight: 150
+        }
+      }
+      const wrapper = shallow(
+        <PopoverContent
+          forwardedRef={forwardedRef}
+          id="mockId"
+          isOpen={true}
+          label="Mock label"
+          offset={10}
+          triggerRect={{
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          }}
+        >
+          <div>This is some content</div>
+        </PopoverContent>
+      )
+      const tree = toJson(wrapper)
+      expect(tree).toMatchSnapshot()
+    })
+
+    it('renders, open & rem offset', () => {
+      const forwardedRef = {
+        current: {
+          focus: jest.fn(),
+          offsetWidth: 150,
+          offsetHeight: 150
+        }
+      }
+      const wrapper = shallow(
+        <PopoverContent
+          forwardedRef={forwardedRef}
+          id="mockId"
+          isOpen={true}
+          label="Mock label"
+          offset="-0.5rem"
+          triggerRect={{
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          }}
+        >
+          <div>This is some content</div>
+        </PopoverContent>
+      )
+      const tree = toJson(wrapper)
+      expect(tree).toMatchSnapshot()
+    })
+
     it('renders, open & top', () => {
       const forwardedRef = {
         current: {
@@ -520,34 +578,6 @@ describe('PopoverContent', () => {
           label="Mock label"
           triggerRect={null}
           style={{ zIndex: '9999' }}
-        >
-          <div>This is some content</div>
-        </PopoverContent>
-      )
-      const tree = toJson(wrapper)
-      expect(tree).toMatchSnapshot()
-    })
-
-    it('renders, full mount', () => {
-      const forwardedRef = {
-        current: {
-          focus: jest.fn(),
-          offsetWidth: 150,
-          offsetHeight: 150
-        }
-      }
-      const wrapper = mount(
-        <PopoverContent
-          forwardedRef={forwardedRef}
-          id="mockId"
-          isOpen={true}
-          label="Mock label"
-          triggerRect={{
-            left: 300,
-            height: 18,
-            top: 200,
-            width: 18
-          }}
         >
           <div>This is some content</div>
         </PopoverContent>

--- a/test/__snapshots__/Popover.test.js.snap
+++ b/test/__snapshots__/Popover.test.js.snap
@@ -179,10 +179,10 @@ exports[`Popover renders with PopoverContent 1`] = `
             role="dialog"
             style={
               Object {
-                "left": 0,
-                "opacity": 0,
+                "left": "0",
+                "opacity": "0",
                 "position": "absolute",
-                "top": 0,
+                "top": "0",
                 "visibility": "hidden",
                 "zIndex": "9999",
               }
@@ -278,7 +278,7 @@ exports[`Popover renders with PopoverContent, open 1`] = `
             aria-hidden="false"
             id="mockId"
             role="dialog"
-            style="z-index: 9999; position: absolute; top: 0px; left: 0px; opacity: 1; visibility: visible;"
+            style="z-index: 9999; position: absolute; opacity: 1; visibility: visible;"
             tabindex="-1"
           >
             <div>
@@ -312,7 +312,7 @@ exports[`Popover renders with PopoverContent, open 1`] = `
                 aria-hidden="false"
                 id="mockId"
                 role="dialog"
-                style="z-index: 9999; position: absolute; top: 0px; left: 0px; opacity: 1; visibility: visible;"
+                style="z-index: 9999; position: absolute; opacity: 1; visibility: visible;"
                 tabindex="-1"
               >
                 <div>
@@ -343,10 +343,10 @@ exports[`Popover renders with PopoverContent, open 1`] = `
             role="dialog"
             style={
               Object {
-                "left": 0,
-                "opacity": 1,
+                "left": "calc(0px + 0px)",
+                "opacity": "1",
                 "position": "absolute",
-                "top": 0,
+                "top": "calc(0px + 0px)",
                 "visibility": "visible",
                 "zIndex": "9999",
               }
@@ -927,7 +927,7 @@ exports[`Popover renders, open 1`] = `
             aria-hidden="false"
             id="mockId"
             role="dialog"
-            style="z-index: 999; position: absolute; top: 10px; left: 10px; opacity: 1; visibility: visible;"
+            style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
             tabindex="-1"
           >
             <div>
@@ -957,7 +957,7 @@ exports[`Popover renders, open 1`] = `
                 aria-hidden="false"
                 id="mockId"
                 role="dialog"
-                style="z-index: 999; position: absolute; top: 10px; left: 10px; opacity: 1; visibility: visible;"
+                style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
                 tabindex="-1"
               >
                 <div>
@@ -984,10 +984,10 @@ exports[`Popover renders, open 1`] = `
             role="dialog"
             style={
               Object {
-                "left": 10,
-                "opacity": 1,
+                "left": "calc(0px + 10px)",
+                "opacity": "1",
                 "position": "absolute",
-                "top": 10,
+                "top": "calc(0px + 10px)",
                 "visibility": "visible",
                 "zIndex": "999",
               }
@@ -1075,7 +1075,7 @@ exports[`Popover renders, open with NO offset 1`] = `
             aria-hidden="false"
             id="mockId"
             role="dialog"
-            style="z-index: 999; position: absolute; top: 0px; left: 0px; opacity: 1; visibility: visible;"
+            style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
             tabindex="-1"
           >
             <div>
@@ -1104,7 +1104,7 @@ exports[`Popover renders, open with NO offset 1`] = `
                 aria-hidden="false"
                 id="mockId"
                 role="dialog"
-                style="z-index: 999; position: absolute; top: 0px; left: 0px; opacity: 1; visibility: visible;"
+                style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
                 tabindex="-1"
               >
                 <div>
@@ -1130,10 +1130,10 @@ exports[`Popover renders, open with NO offset 1`] = `
             role="dialog"
             style={
               Object {
-                "left": 0,
-                "opacity": 1,
+                "left": "calc(0px + 0px)",
+                "opacity": "1",
                 "position": "absolute",
-                "top": 0,
+                "top": "calc(0px + 0px)",
                 "visibility": "visible",
                 "zIndex": "999",
               }
@@ -1220,7 +1220,7 @@ exports[`Popover renders, open with label 1`] = `
             aria-label="Click me"
             id="mockId"
             role="dialog"
-            style="z-index: 999; position: absolute; top: 10px; left: 10px; opacity: 1; visibility: visible;"
+            style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
             tabindex="-1"
           >
             <div>
@@ -1252,7 +1252,7 @@ exports[`Popover renders, open with label 1`] = `
                 aria-label="Click me"
                 id="mockId"
                 role="dialog"
-                style="z-index: 999; position: absolute; top: 10px; left: 10px; opacity: 1; visibility: visible;"
+                style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
                 tabindex="-1"
               >
                 <div>
@@ -1281,10 +1281,10 @@ exports[`Popover renders, open with label 1`] = `
             role="dialog"
             style={
               Object {
-                "left": 10,
-                "opacity": 1,
+                "left": "calc(0px + 10px)",
+                "opacity": "1",
                 "position": "absolute",
-                "top": 10,
+                "top": "calc(0px + 10px)",
                 "visibility": "visible",
                 "zIndex": "999",
               }

--- a/test/__snapshots__/PopoverContent.test.js.snap
+++ b/test/__snapshots__/PopoverContent.test.js.snap
@@ -8,10 +8,10 @@ exports[`PopoverContent component renders 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 0,
-      "opacity": 0,
+      "left": "0",
+      "opacity": "0",
       "position": "absolute",
-      "top": 0,
+      "top": "0",
       "visibility": "hidden",
       "zIndex": "999",
     }
@@ -34,10 +34,10 @@ exports[`PopoverContent component renders, additional props added 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 150,
-      "opacity": 1,
+      "left": "calc(150px - 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 50,
+      "top": "calc(50px - 0px)",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -58,10 +58,10 @@ exports[`PopoverContent component renders, custom style provided 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 150,
-      "opacity": 1,
+      "left": "calc(150px - 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 50,
+      "top": "calc(50px - 0px)",
       "visibility": "visible",
       "zIndex": "9999",
     }
@@ -74,60 +74,6 @@ exports[`PopoverContent component renders, custom style provided 1`] = `
 </div>
 `;
 
-exports[`PopoverContent component renders, full mount 1`] = `
-<PopoverContent
-  forwardedRef={
-    Object {
-      "current": <div
-        aria-hidden="false"
-        aria-label="Mock label"
-        id="mockId"
-        role="dialog"
-        style="z-index: 999; position: absolute; top: 200px; left: 300px; opacity: 1; visibility: visible;"
-        tabindex="-1"
-      >
-        <div>
-          This is some content
-        </div>
-      </div>,
-    }
-  }
-  id="mockId"
-  isOpen={true}
-  label="Mock label"
-  triggerRect={
-    Object {
-      "height": 18,
-      "left": 300,
-      "top": 200,
-      "width": 18,
-    }
-  }
->
-  <div
-    aria-hidden={false}
-    aria-label="Mock label"
-    id="mockId"
-    role="dialog"
-    style={
-      Object {
-        "left": 300,
-        "opacity": 1,
-        "position": "absolute",
-        "top": 200,
-        "visibility": "visible",
-        "zIndex": "999",
-      }
-    }
-    tabIndex="-1"
-  >
-    <div>
-      This is some content
-    </div>
-  </div>
-</PopoverContent>
-`;
-
 exports[`PopoverContent component renders, open & bottom 1`] = `
 <div
   aria-hidden={false}
@@ -136,10 +82,10 @@ exports[`PopoverContent component renders, open & bottom 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 318,
-      "opacity": 1,
+      "left": "calc(318px + 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 218,
+      "top": "calc(218px + 0px)",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -160,10 +106,10 @@ exports[`PopoverContent component renders, open & bottom left 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 150,
-      "opacity": 1,
+      "left": "calc(150px - 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 218,
+      "top": "calc(218px + 0px)",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -184,10 +130,10 @@ exports[`PopoverContent component renders, open & bottom right 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 318,
-      "opacity": 1,
+      "left": "calc(318px + 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 218,
+      "top": "calc(218px + 0px)",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -208,10 +154,34 @@ exports[`PopoverContent component renders, open & left 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 150,
-      "opacity": 1,
+      "left": "calc(150px - 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 134,
+      "top": "134px",
+      "visibility": "visible",
+      "zIndex": "999",
+    }
+  }
+  tabIndex="-1"
+>
+  <div>
+    This is some content
+  </div>
+</div>
+`;
+
+exports[`PopoverContent component renders, open & numeric offset 1`] = `
+<div
+  aria-hidden={false}
+  aria-label="Mock label"
+  id="mockId"
+  role="dialog"
+  style={
+    Object {
+      "left": "234px",
+      "opacity": "1",
+      "position": "absolute",
+      "top": "calc(218px + 10px)",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -232,10 +202,10 @@ exports[`PopoverContent component renders, open & outside bottom 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 125,
-      "opacity": 1,
+      "left": "calc(125px + 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 0,
+      "top": "calc(0px - 0px)",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -256,10 +226,10 @@ exports[`PopoverContent component renders, open & outside left 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 28,
-      "opacity": 1,
+      "left": "calc(28px + 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 134,
+      "top": "134px",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -280,10 +250,10 @@ exports[`PopoverContent component renders, open & outside right 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 125,
-      "opacity": 1,
+      "left": "calc(125px + 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 137.5,
+      "top": "137.5px",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -304,10 +274,34 @@ exports[`PopoverContent component renders, open & outside top 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 234,
-      "opacity": 1,
+      "left": "234px",
+      "opacity": "1",
       "position": "absolute",
-      "top": 28,
+      "top": "calc(28px + 0px)",
+      "visibility": "visible",
+      "zIndex": "999",
+    }
+  }
+  tabIndex="-1"
+>
+  <div>
+    This is some content
+  </div>
+</div>
+`;
+
+exports[`PopoverContent component renders, open & rem offset 1`] = `
+<div
+  aria-hidden={false}
+  aria-label="Mock label"
+  id="mockId"
+  role="dialog"
+  style={
+    Object {
+      "left": "234px",
+      "opacity": "1",
+      "position": "absolute",
+      "top": "calc(218px + -0.5rem)",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -328,10 +322,10 @@ exports[`PopoverContent component renders, open & right 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 318,
-      "opacity": 1,
+      "left": "calc(318px + 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 134,
+      "top": "134px",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -352,10 +346,10 @@ exports[`PopoverContent component renders, open & top 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 234,
-      "opacity": 1,
+      "left": "234px",
+      "opacity": "1",
       "position": "absolute",
-      "top": 50,
+      "top": "calc(50px - 0px)",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -376,10 +370,10 @@ exports[`PopoverContent component renders, open & top left 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 150,
-      "opacity": 1,
+      "left": "calc(150px - 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 134,
+      "top": "134px",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -400,10 +394,10 @@ exports[`PopoverContent component renders, open & top right 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 318,
-      "opacity": 1,
+      "left": "calc(318px + 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 50,
+      "top": "calc(50px - 0px)",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -424,10 +418,10 @@ exports[`PopoverContent component renders, open 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 0,
-      "opacity": 1,
+      "left": "calc(0px + 0px)",
+      "opacity": "1",
       "position": "absolute",
-      "top": 0,
+      "top": "calc(0px + 0px)",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -448,10 +442,10 @@ exports[`PopoverContent component renders, triggerRect null 1`] = `
   role="dialog"
   style={
     Object {
-      "left": 0,
-      "opacity": 1,
+      "left": "0",
+      "opacity": "1",
       "position": "absolute",
-      "top": 0,
+      "top": "0",
       "visibility": "visible",
       "zIndex": "9999",
     }
@@ -513,10 +507,10 @@ exports[`PopoverContent container renders 1`] = `
         role="dialog"
         style={
           Object {
-            "left": 0,
-            "opacity": 0,
+            "left": "0",
+            "opacity": "0",
             "position": "absolute",
-            "top": 0,
+            "top": "0",
             "visibility": "hidden",
             "zIndex": "999",
           }

--- a/test/getPCStyle.test.js
+++ b/test/getPCStyle.test.js
@@ -1,0 +1,983 @@
+import getPCStyle from '../source/getPCStyle'
+
+describe('getPCStyle', () => {
+
+  describe('when NOT open', () => {
+
+    it('returns default', () => {
+      const res = getPCStyle({
+        height: 100,
+        isOpen: false,
+        style: { padding: '1em' },
+        triggerRect: {
+          left: 300,
+          height: 18,
+          top: 200,
+          width: 18
+        },
+        width: 200
+      })
+      const expected = {
+        left: '0',
+        opacity: '0',
+        padding: '1em',
+        position: 'absolute',
+        top: '0',
+        visibility: 'hidden',
+        zIndex: '999'
+      }
+      expect(res).toEqual(expected)
+    })
+
+  })
+
+  describe('when triggerRect absent', () => {
+
+    it('returns default', () => {
+      const res = getPCStyle({
+        height: 100,
+        isOpen: true,
+        style: { padding: '1em' },
+        triggerRect: null,
+        width: 200
+      })
+      const expected = {
+        left: '0',
+        opacity: '1',
+        padding: '1em',
+        position: 'absolute',
+        top: '0',
+        visibility: 'visible',
+        zIndex: '999'
+      }
+      expect(res).toEqual(expected)
+    })
+
+  })
+
+  describe('when open', () => {
+
+    describe('default', () => {
+
+      it('returns bottom styles, no offset', () => {
+        const res = getPCStyle({
+          height: 100,
+          isOpen: true,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: '209px',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + 0px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns bottom styles, numeric offset', () => {
+        const res = getPCStyle({
+          height: 100,
+          isOpen: true,
+          offset: 10,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: '209px',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + 10px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns bottom styles, rem offset', () => {
+        const res = getPCStyle({
+          height: 100,
+          isOpen: true,
+          offset: '-0.5rem',
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: '209px',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + -0.5rem)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+    })
+
+    describe('bottom right', () => {
+
+      it('returns styles, no offset', () => {
+        const res = getPCStyle({
+          dirBottom: true,
+          dirRight: true,
+          height: 100,
+          isOpen: true,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(318px + 0px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + 0px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, numeric offset', () => {
+        const res = getPCStyle({
+          dirBottom: true,
+          dirRight: true,
+          height: 100,
+          isOpen: true,
+          offset: 10,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(318px + 10px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + 10px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, rem offset', () => {
+        const res = getPCStyle({
+          dirBottom: true,
+          dirRight: true,
+          height: 100,
+          isOpen: true,
+          offset: '-0.5rem',
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(318px + -0.5rem)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + -0.5rem)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+    })
+
+    describe('bottom', () => {
+
+      it('returns styles, no offset', () => {
+        const res = getPCStyle({
+          height: 100,
+          isOpen: true,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: '209px',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + 0px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, numeric offset', () => {
+        const res = getPCStyle({
+          height: 100,
+          isOpen: true,
+          offset: 10,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: '209px',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + 10px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, rem offset', () => {
+        const res = getPCStyle({
+          height: 100,
+          isOpen: true,
+          offset: '-0.5rem',
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: '209px',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + -0.5rem)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+    })
+
+    describe('bottom left', () => {
+
+      it('returns styles, no offset', () => {
+        const res = getPCStyle({
+          dirBottom: true,
+          dirLeft: true,
+          height: 100,
+          isOpen: true,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(100px - 0px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + 0px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, numeric offset', () => {
+        const res = getPCStyle({
+          dirBottom: true,
+          dirLeft: true,
+          height: 100,
+          isOpen: true,
+          offset: 10,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(100px - 10px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + 10px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, rem offset', () => {
+        const res = getPCStyle({
+          dirBottom: true,
+          dirLeft: true,
+          height: 100,
+          isOpen: true,
+          offset: '-0.5rem',
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(100px - -0.5rem)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(218px + -0.5rem)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+    })
+
+    describe('left', () => {
+
+      it('returns styles, no offset', () => {
+        const res = getPCStyle({
+          dirLeft: true,
+          height: 100,
+          isOpen: true,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(100px - 0px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: '159px',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, numeric offset', () => {
+        const res = getPCStyle({
+          dirLeft: true,
+          height: 100,
+          isOpen: true,
+          offset: 10,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(100px - 10px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: '159px',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, rem offset', () => {
+        const res = getPCStyle({
+          dirLeft: true,
+          height: 100,
+          isOpen: true,
+          offset: '-0.5rem',
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(100px - -0.5rem)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: '159px',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+    })
+
+    describe('top left', () => {
+
+      it('returns styles, no offset', () => {
+        const res = getPCStyle({
+          dirLeft: true,
+          dirTop: true,
+          height: 100,
+          isOpen: true,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(100px - 0px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(100px - 0px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, numeric offset', () => {
+        const res = getPCStyle({
+          dirLeft: true,
+          dirTop: true,
+          height: 100,
+          isOpen: true,
+          offset: 10,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(100px - 10px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(100px - 10px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, rem offset', () => {
+        const res = getPCStyle({
+          dirLeft: true,
+          dirTop: true,
+          height: 100,
+          isOpen: true,
+          offset: '-0.5rem',
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(100px - -0.5rem)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(100px - -0.5rem)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+    })
+
+    describe('top', () => {
+
+      it('returns styles, no offset', () => {
+        const res = getPCStyle({
+          dirTop: true,
+          height: 100,
+          isOpen: true,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: '209px',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(100px - 0px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, numeric offset', () => {
+        const res = getPCStyle({
+          dirTop: true,
+          height: 100,
+          isOpen: true,
+          offset: 10,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: '209px',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(100px - 10px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, rem offset', () => {
+        const res = getPCStyle({
+          dirTop: true,
+          height: 100,
+          isOpen: true,
+          offset: '-0.5rem',
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: '209px',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(100px - -0.5rem)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+    })
+
+    describe('top right', () => {
+
+      it('returns styles, no offset', () => {
+        const res = getPCStyle({
+          dirRight: true,
+          dirTop: true,
+          height: 100,
+          isOpen: true,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(318px + 0px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(100px - 0px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, numeric offset', () => {
+        const res = getPCStyle({
+          dirRight: true,
+          dirTop: true,
+          height: 100,
+          isOpen: true,
+          offset: 10,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(318px + 10px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(100px - 10px)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, rem offset', () => {
+        const res = getPCStyle({
+          dirRight: true,
+          dirTop: true,
+          height: 100,
+          isOpen: true,
+          offset: '-0.5rem',
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(318px + -0.5rem)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: 'calc(100px - -0.5rem)',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+    })
+
+    describe('right', () => {
+
+      it('returns styles, no offset', () => {
+        const res = getPCStyle({
+          dirRight: true,
+          height: 100,
+          isOpen: true,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(318px + 0px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: '159px',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, numeric offset', () => {
+        const res = getPCStyle({
+          dirRight: true,
+          height: 100,
+          isOpen: true,
+          offset: 10,
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(318px + 10px)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: '159px',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+      it('returns styles, rem offset', () => {
+        const res = getPCStyle({
+          dirRight: true,
+          height: 100,
+          isOpen: true,
+          offset: '-0.5rem',
+          style: { padding: '1em' },
+          triggerRect: {
+            left: 300,
+            height: 18,
+            top: 200,
+            width: 18
+          },
+          width: 200
+        })
+        const expected = {
+          left: 'calc(318px + -0.5rem)',
+          opacity: '1',
+          padding: '1em',
+          position: 'absolute',
+          top: '159px',
+          visibility: 'visible',
+          zIndex: '999'
+        }
+        expect(res).toEqual(expected)
+      })
+
+    })
+
+  })
+
+  describe('when page offsets present', () => {
+
+    beforeEach(() => {
+      global.pageYOffset = 150
+      global.pageXOffset = 75
+    })
+
+    afterEach(() => {
+      global.pageYOffset = 0
+      global.pageXOffset = 0
+    })
+
+    it('returns default', () => {
+      const res = getPCStyle({
+        height: 100,
+        isOpen: true,
+        style: { padding: '1em' },
+        triggerRect: {
+          left: 300,
+          height: 18,
+          top: 200,
+          width: 18
+        },
+        width: 200
+      })
+      const expected = {
+        left: '284px',
+        opacity: '1',
+        padding: '1em',
+        position: 'absolute',
+        top: 'calc(368px + 0px)',
+        visibility: 'visible',
+        zIndex: '999'
+      }
+      expect(res).toEqual(expected)
+    })
+
+  })
+
+  describe('when outside top', () => {
+
+    it('returns bottom styles', () => {
+      const res = getPCStyle({
+        dirTop: true,
+        height: 100,
+        isOpen: true,
+        style: { padding: '1em' },
+        triggerRect: {
+          left: 300,
+          height: 18,
+          top: 10,
+          width: 18
+        },
+        width: 200
+      })
+      const expected = {
+        left: '209px',
+        opacity: '1',
+        padding: '1em',
+        position: 'absolute',
+        top: 'calc(28px + 0px)',
+        visibility: 'visible',
+        zIndex: '999'
+      }
+      expect(res).toEqual(expected)
+    })
+
+  })
+
+  describe('when outside right', () => {
+
+    it('returns left styles', () => {
+      const res = getPCStyle({
+        dirRight: true,
+        height: 100,
+        isOpen: true,
+        style: { padding: '1em' },
+        triggerRect: {
+          left: 1000,
+          height: 18,
+          top: 200,
+          width: 18
+        },
+        width: 200
+      })
+      const expected = {
+        left: 'calc(800px - 0px)',
+        opacity: '1',
+        padding: '1em',
+        position: 'absolute',
+        top: '159px',
+        visibility: 'visible',
+        zIndex: '999'
+      }
+      expect(res).toEqual(expected)
+    })
+
+  })
+
+  describe('when outside bottom', () => {
+
+    it('returns top styles', () => {
+      const res = getPCStyle({
+        dirBottom: true,
+        height: 100,
+        isOpen: true,
+        style: { padding: '1em' },
+        triggerRect: {
+          left: 300,
+          height: 18,
+          top: 700,
+          width: 18
+        },
+        width: 200
+      })
+      const expected = {
+        left: '209px',
+        opacity: '1',
+        padding: '1em',
+        position: 'absolute',
+        top: 'calc(600px - 0px)',
+        visibility: 'visible',
+        zIndex: '999'
+      }
+      expect(res).toEqual(expected)
+    })
+
+  })
+
+  describe('when outside left', () => {
+
+    it('returns right styles', () => {
+      const res = getPCStyle({
+        dirLeft: true,
+        height: 100,
+        isOpen: true,
+        style: { padding: '1em' },
+        triggerRect: {
+          left: 5,
+          height: 18,
+          top: 200,
+          width: 18
+        },
+        width: 200
+      })
+      const expected = {
+        left: 'calc(23px + 0px)',
+        opacity: '1',
+        padding: '1em',
+        position: 'absolute',
+        top: '159px',
+        visibility: 'visible',
+        zIndex: '999'
+      }
+      expect(res).toEqual(expected)
+    })
+
+  })
+
+})


### PR DESCRIPTION
* allows `offset` property to receive either a number _or_ any valid CSS unit that can be used with `calc`
* moves popover content style builder to separate module and adds TONS of tests for it
* removes `full mount` popover content spec, as `jsdom` doesn't support CSS `calc()`, and the test is superfluous anyway