### PR TITLE
Switch directions refinement

### DIFF
--- a/source/getPCStyle.js
+++ b/source/getPCStyle.js
@@ -71,10 +71,10 @@ const getPCStyle = ({
     dirLeft && toLeft,
     (dirTop || dirBottom) && !dirLeft && !dirRight && toMiddleX,
     (dirRight || dirLeft) && !dirTop && !dirBottom && toMiddleY,
-    isOutsideTop && toBottom,
-    isOutsideRight && toLeft,
-    isOutsideBottom && toTop,
-    isOutsideLeft && toRight
+    dirTop && isOutsideTop && toBottom,
+    dirRight && isOutsideRight && toLeft,
+    dirBottom && isOutsideBottom && toTop,
+    dirLeft && isOutsideLeft && toRight
   )
 }
 

--- a/test/__snapshots__/Popover.test.js.snap
+++ b/test/__snapshots__/Popover.test.js.snap
@@ -278,7 +278,7 @@ exports[`Popover renders with PopoverContent, open 1`] = `
             aria-hidden="false"
             id="mockId"
             role="dialog"
-            style="z-index: 9999; position: absolute; opacity: 1; visibility: visible;"
+            style="z-index: 9999; position: absolute; left: 0px; opacity: 1; visibility: visible;"
             tabindex="-1"
           >
             <div>
@@ -312,7 +312,7 @@ exports[`Popover renders with PopoverContent, open 1`] = `
                 aria-hidden="false"
                 id="mockId"
                 role="dialog"
-                style="z-index: 9999; position: absolute; opacity: 1; visibility: visible;"
+                style="z-index: 9999; position: absolute; left: 0px; opacity: 1; visibility: visible;"
                 tabindex="-1"
               >
                 <div>
@@ -343,7 +343,7 @@ exports[`Popover renders with PopoverContent, open 1`] = `
             role="dialog"
             style={
               Object {
-                "left": "calc(0px + 0px)",
+                "left": "0px",
                 "opacity": "1",
                 "position": "absolute",
                 "top": "calc(0px + 0px)",
@@ -927,7 +927,7 @@ exports[`Popover renders, open 1`] = `
             aria-hidden="false"
             id="mockId"
             role="dialog"
-            style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
+            style="z-index: 999; position: absolute; left: 0px; opacity: 1; visibility: visible;"
             tabindex="-1"
           >
             <div>
@@ -957,7 +957,7 @@ exports[`Popover renders, open 1`] = `
                 aria-hidden="false"
                 id="mockId"
                 role="dialog"
-                style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
+                style="z-index: 999; position: absolute; left: 0px; opacity: 1; visibility: visible;"
                 tabindex="-1"
               >
                 <div>
@@ -984,7 +984,7 @@ exports[`Popover renders, open 1`] = `
             role="dialog"
             style={
               Object {
-                "left": "calc(0px + 10px)",
+                "left": "0px",
                 "opacity": "1",
                 "position": "absolute",
                 "top": "calc(0px + 10px)",
@@ -1075,7 +1075,7 @@ exports[`Popover renders, open with NO offset 1`] = `
             aria-hidden="false"
             id="mockId"
             role="dialog"
-            style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
+            style="z-index: 999; position: absolute; left: 0px; opacity: 1; visibility: visible;"
             tabindex="-1"
           >
             <div>
@@ -1104,7 +1104,7 @@ exports[`Popover renders, open with NO offset 1`] = `
                 aria-hidden="false"
                 id="mockId"
                 role="dialog"
-                style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
+                style="z-index: 999; position: absolute; left: 0px; opacity: 1; visibility: visible;"
                 tabindex="-1"
               >
                 <div>
@@ -1130,7 +1130,7 @@ exports[`Popover renders, open with NO offset 1`] = `
             role="dialog"
             style={
               Object {
-                "left": "calc(0px + 0px)",
+                "left": "0px",
                 "opacity": "1",
                 "position": "absolute",
                 "top": "calc(0px + 0px)",
@@ -1220,7 +1220,7 @@ exports[`Popover renders, open with label 1`] = `
             aria-label="Click me"
             id="mockId"
             role="dialog"
-            style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
+            style="z-index: 999; position: absolute; left: 0px; opacity: 1; visibility: visible;"
             tabindex="-1"
           >
             <div>
@@ -1252,7 +1252,7 @@ exports[`Popover renders, open with label 1`] = `
                 aria-label="Click me"
                 id="mockId"
                 role="dialog"
-                style="z-index: 999; position: absolute; opacity: 1; visibility: visible;"
+                style="z-index: 999; position: absolute; left: 0px; opacity: 1; visibility: visible;"
                 tabindex="-1"
               >
                 <div>
@@ -1281,7 +1281,7 @@ exports[`Popover renders, open with label 1`] = `
             role="dialog"
             style={
               Object {
-                "left": "calc(0px + 10px)",
+                "left": "0px",
                 "opacity": "1",
                 "position": "absolute",
                 "top": "calc(0px + 10px)",

--- a/test/__snapshots__/PopoverContent.test.js.snap
+++ b/test/__snapshots__/PopoverContent.test.js.snap
@@ -34,10 +34,10 @@ exports[`PopoverContent component renders, additional props added 1`] = `
   role="dialog"
   style={
     Object {
-      "left": "calc(150px - 0px)",
+      "left": "234px",
       "opacity": "1",
       "position": "absolute",
-      "top": "calc(50px - 0px)",
+      "top": "calc(218px + 0px)",
       "visibility": "visible",
       "zIndex": "999",
     }
@@ -58,10 +58,10 @@ exports[`PopoverContent component renders, custom style provided 1`] = `
   role="dialog"
   style={
     Object {
-      "left": "calc(150px - 0px)",
+      "left": "234px",
       "opacity": "1",
       "position": "absolute",
-      "top": "calc(50px - 0px)",
+      "top": "calc(218px + 0px)",
       "visibility": "visible",
       "zIndex": "9999",
     }
@@ -202,7 +202,7 @@ exports[`PopoverContent component renders, open & outside bottom 1`] = `
   role="dialog"
   style={
     Object {
-      "left": "calc(125px + 0px)",
+      "left": "37.5px",
       "opacity": "1",
       "position": "absolute",
       "top": "calc(0px - 0px)",
@@ -250,7 +250,7 @@ exports[`PopoverContent component renders, open & outside right 1`] = `
   role="dialog"
   style={
     Object {
-      "left": "calc(125px + 0px)",
+      "left": "calc(-50px - 0px)",
       "opacity": "1",
       "position": "absolute",
       "top": "137.5px",
@@ -418,7 +418,7 @@ exports[`PopoverContent component renders, open 1`] = `
   role="dialog"
   style={
     Object {
-      "left": "calc(0px + 0px)",
+      "left": "-75px",
       "opacity": "1",
       "position": "absolute",
       "top": "calc(0px + 0px)",


### PR DESCRIPTION
## Description
A wide popover can get pushed to the right when its in
the bottom direction.
This is caused by the code thats intended to switch the direction
of the popover if its off the screen.

The fix is to only switch directions if we're outside
of the configured direction.

## Links
- Issue: https://github.com/rpearce/react-popover-a11y/issues/30